### PR TITLE
Adding focus to the guess textbox on init

### DIFF
--- a/static/semantle.js
+++ b/static/semantle.js
@@ -239,6 +239,7 @@ let Semantle = (function() {
             event.stopPropagation();
         });
 
+        $('#guess').focus();
 
 
         document.querySelectorAll(".dialog-underlay, .dialog-close, #capitalized-link").forEach((el) => {


### PR DESCRIPTION
With this PR, when we open the Semantle site, we will not need to click on the `guess` input to start playing.
The focus will be automatically on the `guess` input.