### PR TITLE
Keeping unknown guess value

### DIFF
--- a/static/semantle.js
+++ b/static/semantle.js
@@ -315,13 +315,14 @@ let Semantle = (function() {
                 return false;
             }
 
-            $('#guess')[0].value = "";
-
             const guessData = await getSim(guess);
             if (guessData.similarity === null) {
                 $('#error')[0].textContent = `אני לא מכיר את המילה ${guess}.`;
+                $('#guess')[0].select();
                 return false;
             }
+
+            $('#guess')[0].value = "";
 
             let score = guessData.similarity;
             const distance = guessData.distance;


### PR DESCRIPTION
Most of the cases of unknown guesses are due to typos, and it is frustrating to rewrite the guess again.
This change will make it much easier to fix your guess, by not clearing the value in the guess input after unknown guesses.
The word stays selected, so if you still want to guess something else you can just start typing.

This is the existing:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/15929473/203094597-ffd3103f-6451-460a-9b70-deeccfe96a5b.png">

This is after my changes:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/15929473/203094319-6fe93ccf-3d32-40e1-84df-531bf25314ca.png">

