### PR TITLE
Fix `NaN` solver count.

### DIFF
--- a/static/semantle.js
+++ b/static/semantle.js
@@ -366,7 +366,7 @@ let Semantle = (function() {
             let egg = guessData.egg;
             cache[guess] = guessData;
             storage.setItem("cache", JSON.stringify(cache));
-            if (guessData.solver_count !== undefined) {
+            if (guessData.solver_count != null) {
                 storage.setItem("solverCount", JSON.stringify(guessData.solver_count));
             }
 


### PR DESCRIPTION
Fix #66 
By default, the `solver_count` property is `null`. So when user guess wrong word, it match the condition because `null !== undefined`. This cause a bug when user guess words **after** he won.
(In JS  it's better don't strict equal to `null`/ `undefined`, because they are similar and may be replaced due to a minor code change.)

![image](https://github.com/ishefi/semantle-he/assets/15896603/7e713c91-5390-42f9-9ba3-e4d0541a23d0)
