### PR TITLE
fix share text does not include all distances

### DIFF
--- a/static/semantle.js
+++ b/static/semantle.js
@@ -81,7 +81,7 @@ function solveStory(guesses, puzzleNumber) {
             txt += '🟩'.repeat(greens) + '⬜'.repeat(whites) + ' ';
         }
         txt += ' ' + guess_number;
-        if (greens != 0) {
+        if (distance > 0) {
             txt += ' (' + distance + '/1000)';
         }
         txt += '\n'


### PR DESCRIPTION
we should not rely on the number of greens when deciding to show the distance or not.